### PR TITLE
ci: default branchをmasterからmainに変更

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -2,7 +2,7 @@ name: Deploy static content to Pages
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
 
   workflow_dispatch:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- `.github/workflows/test.yml` のブランチトリガーを `master` → `main` に変更（push・pull_request の 2 箇所）
- `.github/workflows/static.yml` のブランチトリガーを `master` → `main` に変更（push の 1 箇所）

## Background / Motivation
GitHub リポジトリの default branch を `master` から `main` に変更する一環。ワークフローのトリガーを先に `main` に合わせておくことで、GitHub 側の設定変更後もCI/CDが継続して動作するようにする。