### PR TITLE
chore: renovate設定を刷新しghalintワークフローを追加する

### DIFF
--- a/.github/workflows/ghalint.yml
+++ b/.github/workflows/ghalint.yml
@@ -1,0 +1,86 @@
+name: "Run Actions Security Check"
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  changes:
+    runs-on: ubuntu-slim
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      workflows: ${{ steps.filter.outputs.workflows }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        id: filter
+        with:
+          filters: |
+            workflows:
+              - '.github/**'
+
+  ghalint:
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      attestations: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install ghalint
+        run: |
+          # renovate: datasource=github-releases depName=suzuki-shunsuke/ghalint
+          version=v1.5.6
+          gh release download -R suzuki-shunsuke/ghalint "${version}" -p "ghalint_${version#v}_linux_amd64.tar.gz"
+          gh attestation verify "ghalint_${version#v}_linux_amd64.tar.gz" \
+            -R suzuki-shunsuke/ghalint \
+            --signer-workflow suzuki-shunsuke/go-release-workflow/.github/workflows/release.yaml
+          tar xzf "ghalint_${version#v}_linux_amd64.tar.gz" ghalint
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run ghalint run
+        run: ./ghalint run
+
+      - name: Run ghalint act
+        run: ./ghalint act
+
+  actionlint:
+    needs: changes
+    if: needs.changes.outputs.workflows == 'true'
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      attestations: read
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install actionlint
+        run: |
+          # renovate: datasource=github-releases depName=rhysd/actionlint
+          version=v1.7.12
+          gh release download -R rhysd/actionlint "${version}" -p "actionlint_${version#v}_linux_amd64.tar.gz"
+          gh attestation verify "actionlint_${version#v}_linux_amd64.tar.gz" --repo rhysd/actionlint
+          tar xzf "actionlint_${version#v}_linux_amd64.tar.gz" actionlint
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Run actionlint
+        run: ./actionlint

--- a/renovate.json
+++ b/renovate.json
@@ -1,38 +1,128 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    ":dependencyDashboard",
+    ":semanticCommits",
+    ":timezone(Asia/Tokyo)",
+    "helpers:pinGitHubActionDigestsToSemver",
+    "mergeConfidence:all-badges"
   ],
-  "packageRules": [
-    {
-      "updateTypes": ["digest"]
-    }
+  "labels": [
+    "dependencies"
   ],
+  "reviewers": [
+    "yagihash"
+  ],
+  "schedule": [
+    "after 8pm on friday"
+  ],
+  "prHourlyLimit": 0,
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "rangeStrategy": "pin",
+  "minimumReleaseAge": "3 days",
+  "osvVulnerabilityAlerts": true,
   "postUpdateOptions": [
     "gomodTidy"
   ],
-  "rangeStrategy": "pin",
-  "dependencies": {
-    "labels": [
-      "renovate"
-    ],
-    "vulnerabilityAlerts": {
-      "labels": [
-        "renovate",
-        "security"
-      ]
-    }
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "after 8pm on friday"
+    ]
   },
-  "devDependencies": {
-    "labels": [
-      "renovate"
-    ],
-    "vulnerabilityAlerts": {
-      "labels": [
-        "renovate",
-        "security"
+  "packageRules": [
+    {
+      "description": "Never automerge major updates",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false
+    },
+    {
+      "description": "Pin GitHub Actions to commit SHA for security",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "pinDigests": true
+    },
+    {
+      "description": "Group and automerge GitHub Actions digest/minor/patch updates",
+      "groupName": "GitHub Actions",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "digest"
+      ],
+      "automerge": true
+    },
+    {
+      "description": "Group Google Cloud SDK updates together",
+      "groupName": "Google Cloud SDK",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchPackageNames": [
+        "cloud.google.com/go{/,}**"
       ]
+    },
+    {
+      "description": "Group golang.org/x/* updates together",
+      "groupName": "golang.org/x packages",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchPackageNames": [
+        "golang.org/x{/,}**"
+      ]
+    },
+    {
+      "description": "Group googleapis updates together",
+      "groupName": "googleapis packages",
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchPackageNames": [
+        "google.golang.org{/,}**"
+      ]
+    },
+    {
+      "description": "Automerge Go module minor/patch updates",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "automerge": true
     }
-  },
-  "automerge": true
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update ghalint and actionlint versions in ghalint workflow",
+      "fileMatch": ["^\\.github/workflows/ghalint\\.yml$"],
+      "matchStrings": ["# renovate: datasource=(?<datasource>[^\\s]+) depName=(?<depName>[^\\s]+)\\s+version=v?(?<currentValue>[^\\s]+)"],
+      "versioningTemplate": "semver"
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": [
+      "security"
+    ],
+    "automerge": true,
+    "minimumReleaseAge": null,
+    "schedule": [
+      "at any time"
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

### renovate.json
- `config:base` → `config:recommended` に更新
- `:dependencyDashboard` / `:semanticCommits` / `:timezone(Asia/Tokyo)` / `helpers:pinGitHubActionDigestsToSemver` / `mergeConfidence:all-badges` を追加
- スケジュール（毎週金曜夜）・`minimumReleaseAge: 3 days`・`osvVulnerabilityAlerts` を追加
- `lockFileMaintenance` を有効化
- `packageRules` を整理：major は automerge 無効、GitHub Actions はグループ化、Go モジュール（minor/patch）は automerge
- Google Cloud SDK / golang.org/x / google.golang.org のグループルールを追加
- ghalint/actionlint のバージョンを renovate で管理する `customManagers` を追加
- `vulnerabilityAlerts` を追加（security ラベル付き・即時 automerge）

### .github/workflows/ghalint.yml
- `ghalint run` / `ghalint act` / `actionlint` を実行するワークフローを新規追加
- `.github/**` に変更があった場合のみ実行（paths-filter で制御）
- ghalint・actionlint はリリースバイナリをダウンロードして attestation 検証後に実行

## Background / Motivation
yagihash/ghat の renovate 設定を参考に、依存関係の自動更新・セキュリティ管理を強化するのだ。ghalint によるワークフローのセキュリティ継続チェックも同時に導入する。