### PR TITLE
chore: tagprを導入する

### DIFF
--- a/.github/ghmint/writer.rego
+++ b/.github/ghmint/writer.rego
@@ -1,0 +1,14 @@
+package ghmint
+
+issuer := "https://token.actions.githubusercontent.com"
+
+permissions := {
+	"contents": "write",
+	"pull_requests": "write",
+}
+
+default allow := false
+
+allow if {
+	input.sub == "repo:yagihash/fsw-calendar:ref:refs/heads/main"
+}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,31 @@
+name: tagpr
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Create GitHub App Token
+        id: token
+        uses: yagihash/ghmint-action@be57533eef7f69550d06f0c93eede5589158281a # v1.0.0
+        with:
+          scope: ${{ github.repository }}
+          policy: writer
+
+      - uses: Songmu/tagpr@555e72cee68c09d43dc2337dc9ba890955b630da # v1.19.0
+        env:
+          GITHUB_TOKEN: ${{ steps.token.outputs.token }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,6 @@
+[tagpr]
+	releaseBranch = main
+	vPrefix = true
+	release = true
+	changelog = true
+	versionFile = -


### PR DESCRIPTION
## Summary
- `.tagpr` 設定ファイルを追加（`vPrefix=true`・`release=true`・`changelog=true`・`versionFile=-`）
- `.github/workflows/tagpr.yml` を追加（main へのプッシュで起動）
- `.github/ghmint/writer.rego` を追加（ghmint-action が main ブランチからのトークン要求を許可）
- `ghmint-action` で GitHub App Token を取得し tagpr に渡す（ghat と同じ構成）

## Background / Motivation
main へのマージをトリガーにリリース PR の自動生成・タグ付け・GitHub Release 作成・CHANGELOG 更新を自動化する。ghat で実績のある tagpr + ghmint-action の構成を fsw-calendar にも導入する。

ghat との差分:
- `release = true`・`changelog = true`（ghat は別途 release ワークフローを持つが、fsw-calendar はバイナリ配布がないため tagpr に直接任せる）
- `versionFile = -`（更新すべきバージョンファイルなし）
- ghmint ポリシーは main ブランチからのアクセスのみ許可（release ワークフロー用の environment・tag ルールは不要）