### PR TITLE
feat: GitHub Actions で Calendar sync ワークフローを追加する

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,0 +1,56 @@
+name: sync
+
+on:
+  schedule:
+    - cron: '0 17 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  sync:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    environment: main
+    strategy:
+      matrix:
+        include:
+          - name: ss-4
+            course: ss
+            class: ss-4
+            calendar_id: 25dfc5f523279ce53fbeb5a90eecfe45b2bdc8fdbe8a17bbae28ee77a7f53753@group.calendar.google.com
+          - name: t-4
+            course: rc
+            class: t-4
+            calendar_id: 0a31d519fe9246513b2bc7937d0191d60058eb3c74ec8dea8481642331c48305@group.calendar.google.com
+          - name: ns-4
+            course: rc
+            class: ns-4
+            calendar_id: 4860bb7c2c62bf60cd5264495d3e739e06d82eaf66fdfb6f0e3f77e053d1b6fe@group.calendar.google.com
+          - name: s-4
+            course: rc
+            class: s-4
+            calendar_id: ccc748b5eb57fc6d8d01d2a380f7833225b347a54b816d23a5dbabb209f263b3@group.calendar.google.com
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
+        with:
+          go-version-file: go.mod
+
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: projects/346973490040/locations/global/workloadIdentityPools/github-yagihash-pool/providers/fsw-calendar-provider
+          service_account: fsw-calendar@yagihash-lab.iam.gserviceaccount.com
+
+      - name: sync
+        env:
+          CALENDAR_ID: ${{ matrix.calendar_id }}
+          COURSE: ${{ matrix.course }}
+          CLASS: ${{ matrix.class }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        run: go run ./cmd/run

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -44,8 +44,8 @@ jobs:
 
       - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
-          workload_identity_provider: projects/346973490040/locations/global/workloadIdentityPools/github-yagihash-pool/providers/fsw-calendar-provider
-          service_account: fsw-calendar@yagihash-lab.iam.gserviceaccount.com
+          workload_identity_provider: ${{ vars.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.SERVICE_ACCOUNT_EMAIL }}
 
       - name: sync
         env:

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"cloud.google.com/go/pubsub"
+
+	function "github.com/yagihash/fsw-calendar"
+)
+
+const (
+	exitOK = iota
+	exitError
+)
+
+func main() {
+	os.Exit(run())
+}
+
+func run() int {
+	data, err := json.Marshal(map[string]string{
+		"calendar_id": os.Getenv("CALENDAR_ID"),
+		"course":      os.Getenv("COURSE"),
+		"class":       os.Getenv("CLASS"),
+	})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return exitError
+	}
+
+	if err := function.Register(context.Background(), &pubsub.Message{Data: data}); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return exitError
+	}
+
+	return exitOK
+}


### PR DESCRIPTION
## Summary
- Cloud Functions + Cloud Scheduler の代替として GitHub Actions の `sync` ワークフローを追加
- WIF で `fsw-calendar@yagihash-lab.iam.gserviceaccount.com` として認証し、Google Calendar を更新
- SS-4 / T-4 / NS-4 / S-4 の4クラスを matrix ジョブで並列実行
- `cmd/run/main.go` に CLI エントリーポイントを追加（環境変数から `CALENDAR_ID` / `COURSE` / `CLASS` を受け取り `function.Register` を呼ぶ）

## Background / Motivation
Cloud Function を段階的に廃止して GitHub Actions に移行する。今後 TypeScript への書き換えを予定しており、まず既存 Go コードをそのまま `go run` で動かすワークフローを用意する。