### PR TITLE
fix: sync ワークフローの WIF 設定と environment 指定を修正する

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,7 +13,9 @@ jobs:
   sync:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    environment: main
+    environment:
+      name: main
+      deployment: false
     strategy:
       matrix:
         include:


### PR DESCRIPTION
## Summary
- WIF 接続情報（`workload_identity_provider` / `service_account`）を GitHub Environment Variables から参照するよう変更
- `environment: main` を `environment: { name: main, deployment: false }` に変更し deployment レコードを作らないようにする

## Background / Motivation
初回 workflow_dispatch で `vars.WORKLOAD_IDENTITY_PROVIDER` が空文字になり auth が失敗していた。Environment Variables が未設定だったため、正しく設定した上でワークフロー側も対応する形式に修正する。