### PR TITLE
ci: cicd-sensor によるランタイムセキュリティ監視を導入

### DIFF
--- a/.github/workflows/ghalint.yml
+++ b/.github/workflows/ghalint.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   changes:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       contents: read
@@ -16,6 +16,11 @@ jobs:
     outputs:
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
+        with:
+          enable-html-report: "false"
+          enable-attestation-artifact: "false"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -29,13 +34,18 @@ jobs:
   ghalint:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       attestations: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
+        with:
+          enable-html-report: "false"
+          enable-attestation-artifact: "false"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -61,13 +71,18 @@ jobs:
   actionlint:
     needs: changes
     if: needs.changes.outputs.workflows == 'true'
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       attestations: read
 
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
+        with:
+          enable-html-report: "false"
+          enable-attestation-artifact: "false"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
+      - uses: cicd-sensor/cicd-sensor-action@1935de498397aa7b9bf6ac7ca822ddb430a34843 # v0.0.31
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
## Summary
- `cicd-sensor/cicd-sensor-action`（eBPF ベースのランタイムサプライチェーン攻撃検知センサー）を導入
- **test.yml**: `test` ジョブ先頭にセンサーを追加（単一ジョブなのでアーティファクトは既定で有効）
- **ghalint.yml**: 3ジョブ（`changes`/`ghalint`/`actionlint`）を `ubuntu-slim` → `ubuntu-latest` に変更し、各ジョブ先頭にセンサーを追加。1 run 内の同名アーティファクト衝突を避けるため `enable-html-report` / `enable-attestation-artifact` を `false` に設定
- **sync.yml**: 導入見送り（4並列 matrix で固定アーティファクト名の衝突を回避できないため）
- min-age 7 を満たす最新タグ **v0.0.31**（`1935de49`）に SHA ピン

## Background / Motivation
`pnpm install` などの依存解決や外部バイナリ実行が走るジョブを実行時に監視し、サプライチェーン攻撃を検知できるようにするのが目的。

ランナーと権限について調査した結果:
- cicd-sensor は eBPF を使うため **`ubuntu-slim` は非対応**（共有 VM 上のコンテナでホスト eBPF 環境が無い）。そのため ghalint.yml は `ubuntu-latest` 化が必要だった
- アーティファクト名（`cicd-sensor-report` 等）は固定でカスタマイズ不可なため、複数ジョブ/matrix が既定のまま上げると `actions/upload-artifact@v4` で衝突する。ghalint.yml は無効化で回避、sync.yml は回避困難のため見送り
- アーティファクトのアップロードは `@actions/artifact`（ランタイムトークン経由）で行われ `GITHUB_TOKEN` の scope に依存しないため、`actions: write` 等の追加権限は不要

pinact / ghalint run / ghalint act / actionlint はすべてローカルでパス済み。